### PR TITLE
Create CocoaPods' Podspec

### DIFF
--- a/GrowthPush.podspec
+++ b/GrowthPush.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
     s.name         = "GrowthPush"
-    s.version      = "1.0.5"
+    s.version      = "1.0.6"
     s.summary      = "GrowthPush SDK for iPhone/iPad"
     s.description  = <<-DESC
                      GrowthPush is push notification and analysis platform for smart devices.


### PR DESCRIPTION
Allows to instal GrowthPush from [CocoaPods](http://cocoapods.org).

Also avoids conflicts with projects that already use/use a different version of AFNetworking.
